### PR TITLE
Handle untranslated errors

### DIFF
--- a/Classes/Controller/UploaderCommandController.php
+++ b/Classes/Controller/UploaderCommandController.php
@@ -136,9 +136,14 @@ class UploaderCommandController extends CommandController {
 				'extension_uploader',
 				array($extkey, $this->uploader->getReleasedVersion())
 			);
+			$this->outputLine($message);
 		} catch (\T3x\ExtensionUploader\UploaderException $e) {
 			$message = LocalizationUtility::translate('exception.' . $e->getCode(), 'extension_uploader');
+			if ($message == '') {
+				$message = 'Error: ' . $e->getMessage();
+			}
+			$this->outputLine($message);
+			$this->quit(1);
 		}
-		$this->outputLine($message);
 	}
 }


### PR DESCRIPTION
Instead of outputting an empty string, the original exception message
is shown if an error does not have a translation.

Fixes issue #8.

The exit code is still 0, but that's because of http://forge.typo3.org/issues/58781
